### PR TITLE
Update building block API links

### DIFF
--- a/components/product-offerings/building-blocks-links.js
+++ b/components/product-offerings/building-blocks-links.js
@@ -49,7 +49,7 @@ export const BuildingBlocksInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/containers/alerts.html"
+                                    href="https://cdcgov.github.io/phdi/latest/containers/alerts.html"
                                     target='_blank'
                                 >
                                     Alerts BB
@@ -63,7 +63,7 @@ export const BuildingBlocksInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/containers/fhir-converter.html"
+                                    href="https://cdcgov.github.io/phdi/latest/containers/fhir-converter.html"
                                     target='_blank'
                                 >
                                     FHIR Converter BB
@@ -77,7 +77,7 @@ export const BuildingBlocksInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/containers/ingestion.html"
+                                    href="https://cdcgov.github.io/phdi/latest/containers/ingestion.html"
                                     target='_blank'>
                                     Ingestion BB
                                 </Link>
@@ -90,7 +90,7 @@ export const BuildingBlocksInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/containers/message_parser.html"
+                                    href="https://cdcgov.github.io/phdi/latest/containers/message_parser.html"
                                     target='_blank'>
                                     Message Parser BB
                                 </Link>
@@ -105,7 +105,7 @@ export const BuildingBlocksInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/containers/record_linkage.html"
+                                    href="https://cdcgov.github.io/phdi/latest/containers/record_linkage.html"
                                     target='_blank'>
                                     Record Linkage BB
                                 </Link>
@@ -118,7 +118,7 @@ export const BuildingBlocksInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/containers/tabulation.html"
+                                    href="https://cdcgov.github.io/phdi/latest/containers/tabulation.html"
                                     target='_blank'>
                                     Tabulation BB
                                 </Link>
@@ -131,7 +131,7 @@ export const BuildingBlocksInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/containers/validation.html"
+                                    href="https://cdcgov.github.io/phdi/latest/containers/validation.html"
                                     target='_blank'>
                                     Validation BB
                                 </Link>

--- a/components/product-offerings/building-blocks-links.js
+++ b/components/product-offerings/building-blocks-links.js
@@ -90,7 +90,7 @@ export const BuildingBlocksInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/latest/containers/message_parser.html"
+                                    href="https://cdcgov.github.io/phdi/latest/containers/message-parser.html"
                                     target='_blank'>
                                     Message Parser BB
                                 </Link>

--- a/components/product-offerings/software-development-kit-info.js
+++ b/components/product-offerings/software-development-kit-info.js
@@ -48,7 +48,7 @@ export const SoftwareDevelopmentKitInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/sdk/phdi/cloud.html"
+                                    href="https://cdcgov.github.io/phdi/latest/sdk/phdi/cloud.html"
                                     target='_blank'
                                 >
                                     Cloud
@@ -62,7 +62,7 @@ export const SoftwareDevelopmentKitInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/sdk/phdi/fhir.html"
+                                    href="https://cdcgov.github.io/phdi/latest/sdk/phdi/fhir.html"
                                     target='_blank'
                                 >
                                     FHIR
@@ -76,7 +76,7 @@ export const SoftwareDevelopmentKitInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/sdk/phdi/geospatial.html"
+                                    href="https://cdcgov.github.io/phdi/latest/sdk/phdi/geospatial.html"
                                     target='_blank'>
                                     Geospatial
                                 </Link>
@@ -89,7 +89,7 @@ export const SoftwareDevelopmentKitInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/sdk/phdi/harmonization.html"
+                                    href="https://cdcgov.github.io/phdi/latest/sdk/phdi/harmonization.html"
                                     target='_blank'>
                                     Harmonization
                                 </Link>
@@ -104,7 +104,7 @@ export const SoftwareDevelopmentKitInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/sdk/phdi/linkage.html"
+                                    href="https://cdcgov.github.io/phdi/latest/sdk/phdi/linkage.html"
                                     target='_blank'>
                                     Linkage
                                 </Link>
@@ -117,7 +117,7 @@ export const SoftwareDevelopmentKitInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/sdk/phdi/tabulation.html"
+                                    href="https://cdcgov.github.io/phdi/latest/sdk/phdi/tabulation.html"
                                     target='_blank'>
                                     Tabulation
                                 </Link>
@@ -130,7 +130,7 @@ export const SoftwareDevelopmentKitInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/sdk/phdi/transport.html"
+                                    href="https://cdcgov.github.io/phdi/latest/sdk/phdi/transport.html"
                                     target='_blank'>
                                     Transport
                                 </Link>
@@ -143,7 +143,7 @@ export const SoftwareDevelopmentKitInfo = () => {
                                 </div>
                                 <Link
                                     className="font-semibold flex-align-self-center"
-                                    href="https://cdcgov.github.io/phdi/sdk/phdi/validation.html"
+                                    href="https://cdcgov.github.io/phdi/latest/sdk/phdi/validation.html"
                                     target='_blank'>
                                     Validation
                                 </Link>


### PR DESCRIPTION
They need a specific release tag for the links to work.